### PR TITLE
Require Store.move doesn't overwrite the target file

### DIFF
--- a/mundane-io/src/main/scala/com/ambiata/mundane/io/Files.scala
+++ b/mundane-io/src/main/scala/com/ambiata/mundane/io/Files.scala
@@ -3,7 +3,7 @@ package io
 
 import com.ambiata.mundane.control._
 import java.io._
-import java.nio.file.{Files => NFiles}
+import java.nio.file.{Files => NFiles, DirectoryNotEmptyException, FileAlreadyExistsException}
 import java.nio.file.StandardCopyOption._
 import scalaz._, Scalaz._
 import scalaz.effect._, Effect._
@@ -40,14 +40,16 @@ object Files {
     _ <- ResultT.using(path.toOutputStream)(Streams.pipe(content, _))
   } yield ()
 
-  def move(src: FilePath, dest: FilePath): ResultT[IO, Unit] = ResultT.safe[IO, Unit] {
+  def move(src: FilePath, dest: FilePath): ResultT[IO, Boolean] = ResultT.safe[IO, Boolean] {
     val srcf = src.toFile
     val destf = dest.toFile
     if (destf.isDirectory)
-      NFiles.move(srcf.toPath, destf.toPath.resolve(srcf.getName), REPLACE_EXISTING)
+      try { NFiles.move(srcf.toPath, destf.toPath.resolve(srcf.getName)); true }
+      catch { case e: DirectoryNotEmptyException => false }
     else {
       destf.getParentFile.mkdirs
-      NFiles.move(srcf.toPath, destf.toPath, REPLACE_EXISTING)
+      try { NFiles.move(srcf.toPath, destf.toPath); true }
+      catch { case e: FileAlreadyExistsException => false }
     }
   }
 

--- a/mundane-store/src/main/scala/com/ambiata/mundane/store/PosixStore.scala
+++ b/mundane-store/src/main/scala/com/ambiata/mundane/store/PosixStore.scala
@@ -34,7 +34,7 @@ case class PosixStore(root: FilePath) extends Store[ResultTIO] with ReadOnlyStor
   def deleteAll(prefix: FilePath): ResultT[IO, Unit] =
     Directories.delete(root </> prefix)
 
-  def move(in: FilePath, out: FilePath): ResultT[IO, Unit] =
+  def move(in: FilePath, out: FilePath): ResultT[IO, Boolean] =
     Files.move(root </> in, root </> out)
 
   def copy(in: FilePath, out: FilePath): ResultT[IO, Unit] =

--- a/mundane-store/src/main/scala/com/ambiata/mundane/store/Store.scala
+++ b/mundane-store/src/main/scala/com/ambiata/mundane/store/Store.scala
@@ -19,7 +19,7 @@ trait WriteOnlyStore[F[_]] {
   def delete(path: FilePath): F[Unit]
   def deleteAll(prefix: FilePath): F[Unit]
 
-  def move(in: FilePath, out: FilePath): F[Unit]
+  def move(in: FilePath, out: FilePath): F[Boolean]
   def moveTo(store: Store[F], in: FilePath, out: FilePath): F[Unit]
 
   def copy(in: FilePath, out: FilePath): F[Unit]


### PR DESCRIPTION
I'm still investigating how to support this on S3 in the best way. Looks like the distributed HDFS implementation also does this by default. 

Wouldn't mind talking about this next week in any case (certainly before we merge or do anything).

/cc @markhibberd 
