### PR TITLE
Add a trace data structure for mixed mode logging.

### DIFF
--- a/mundane-trace/src/main/scala/com/ambiata/mundane/trace/Trace.scala
+++ b/mundane-trace/src/main/scala/com/ambiata/mundane/trace/Trace.scala
@@ -1,0 +1,66 @@
+package com.ambiata.mundane.trace
+
+import com.ambiata.mundane.control._
+
+import scalaz._, Scalaz._, effect._
+
+/*
+ * A category based tracing tool, for optionally journaled logging.
+ *
+ * This construction is specifically designed to be carried around in
+ * a ReaderT sharing the same 'F', this allows for pure computations
+ * to be logged via Writer and allows them to be flushed immediately
+ * when in IO.
+ */
+case class Trace[F[+_]](trace: (Trace.Key, String) => F[Unit]) {
+  def apply(key: Trace.Key, message: String): F[Unit] =
+    trace(key, message)
+
+  def not(keys: List[Trace.Key])(implicit F: Applicative[F]): Trace[F] = {
+    val exclude = keys.toSet
+    filter(k => !exclude.contains(k))
+  }
+
+  def only(keys: List[Trace.Key])(implicit F: Applicative[F]): Trace[F] = {
+    val include = keys.toSet
+    filter(include.contains _)
+  }
+
+  def filter(pred: Trace.Key => Boolean)(implicit F: Applicative[F]): Trace[F] =
+    Trace((k, s) => if (pred(k)) trace(k, s) else ().pure[F])
+}
+
+object Trace {
+  type WriterS[+A] = Writer[Vector[String], A]
+  type WriterKS[+A] = Writer[Vector[(Key, String)], A]
+
+  case class Key(name: String)
+
+  def log[F[+_]](k: Key, message: String): Kleisli[F, Trace[F], Unit] =
+    Kleisli[F, Trace[F], Unit](_(k, message))
+
+  def io[A](a: => Kleisli[WriterKS, Trace[WriterKS], A]): Kleisli[ResultTIO, Trace[ResultTIO], A] =
+    Kleisli[ResultTIO, Trace[ResultTIO], A](trace => {
+      val w = Trace.writerK[Id]
+      val (l, v) = a.run(w).run
+      l.traverseU({ case (k, s) => trace(k, s) }).as(v)
+    })
+
+  def empty[F[+_]: Applicative]: Trace[F] =
+    Trace[F]((_, _) => ().pure[F])
+
+  def stream(out: java.io.PrintStream) : Trace[ResultTIO] =
+    Trace[ResultTIO]((_, s) => ResultT.fromIO { IO { out.println(s) } })
+
+  def out: Trace[ResultTIO] =
+    stream(Console.out)
+
+  def err: Trace[ResultTIO] =
+    stream(Console.err)
+
+  def writer[F[+_]: Applicative]: Trace[({ type l[+a] = WriterT[F, Vector[String], a] })#l] =
+    Trace[({ type l[+a] = WriterT[F, Vector[String], a] })#l]((_, s) => WriterT.put[F, Vector[String], Unit](().pure[F])(Vector(s)))
+
+  def writerK[F[+_]: Applicative]: Trace[({ type l[+a] = WriterT[F, Vector[(Key, String)], a] })#l] =
+    Trace[({ type l[+a] = WriterT[F, Vector[(Key, String)], a] })#l]((k, s) => WriterT.put[F, Vector[(Key, String)], Unit](().pure[F])(Vector(k -> s)))
+}

--- a/mundane-trace/src/test/scala/com/ambiata/mundane/trace/TraceSpec.scala
+++ b/mundane-trace/src/test/scala/com/ambiata/mundane/trace/TraceSpec.scala
@@ -1,0 +1,111 @@
+package com.ambiata.mundane.trace
+
+import com.ambiata.mundane.testing.ResultTIOMatcher._
+import com.ambiata.mundane.data.Lists
+import com.ambiata.mundane.control._
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+import org.specs2._
+import org.scalacheck._, Arbitrary._
+
+import scalaz._, Scalaz._
+
+class TraceSpec extends Specification with ScalaCheck { def is = s2"""
+
+Trace Constructors
+------------------
+
+  Trace.writer accumulates messages               $writer
+  Trace.empty doesn't do anything                 $empty
+  Trace.stream accumulates in stream              $stream
+
+Trace Combinators
+-----------------
+
+  'not' acts as blacklist                         $blacklist
+  'only' acts as whitelist                        $whitelist
+  'filter(const true)' accumulates all messages   $nofilter
+  'filter(const false)' accumulates no messages   $filter
+
+Trace Demonstration
+-------------------
+
+  In a real application you can use pure Writer style
+  logging interspersed with flushed to disk IO based
+  logging $example
+
+"""
+  import Trace.{Key, WriterS}
+
+  val one = Key("one")
+  val two = Key("two")
+
+  def writer = prop((x: Vector[String], y: Vector[String]) =>
+    run(Trace.writer[Id], x, y) must_== (x ++ y))
+
+  def empty = prop((x: Vector[String], y: Vector[String]) =>
+    run(Trace.empty[WriterS], x, y) must_== Vector())
+
+  def stream = prop((x: Vector[String]) =>
+    capture(out => { val trace = Trace.stream(out); x.traverseU(trace(one, _)) })(_ must_==
+     Lists.prepareForFile(x.toList)))
+
+  def blacklist = prop((x: Vector[String], y: Vector[String]) =>
+    run(Trace.writer[Id].not(List(two)), x, y) must_== x)
+
+  def whitelist = prop((x: Vector[String], y: Vector[String]) =>
+    run(Trace.writer[Id].only(List(two)), x, y) must_== y)
+
+  def nofilter = prop((x: Vector[String], y: Vector[String]) =>
+    run(Trace.writer[Id].filter(_ => true), x, y) must_== (x ++ y))
+
+  def filter = prop((x: Vector[String], y: Vector[String]) =>
+    run(Trace.writer[Id].filter(_ => false), x, y) must_== Vector())
+
+  def example = prop((m: Int, n: Int, o: Int) =>  {
+    capture(out => demo.work(m, n, o).run(Trace.stream(out)))(_ must_==
+      s"""working on ${m}, ${n}, ${o}
+         |adding ${m}, ${n}
+         |got ${m + n}
+         |adding ${m + n}, ${o}
+         |got ${m + n + o}
+         |done with ${m + n + o}
+         |""".stripMargin) })
+
+  object demo {
+    import Trace.{Key, log, io, WriterKS}
+
+    type App[A] = ReaderT[ResultTIO, Trace[ResultTIO], A]
+    type Purity[A] = ReaderT[WriterKS, Trace[WriterKS], A]
+
+    val adding = Key("adding")
+    val doing = Key("doing")
+
+    /* Simulating some effectful computation in IO. */
+    def work(m: Int, n: Int, o: Int): App[Unit] = for {
+      _ <- log[ResultTIO](doing, s"working on ${m}, ${n}, ${o}")
+      p <- io { add(m, n).flatMap(add(_, o)) }
+      _ <- log[ResultTIO](doing, s"done with $p")
+    } yield ()
+
+    /* Simulating some pure computation. */
+    def add(m: Int, n: Int): Purity[Int] = for {
+      _ <- log[WriterKS](adding, s"adding ${m}, ${n}")
+      o =  m + n
+      _ <- log[WriterKS](adding, s"got $o")
+    } yield o
+  }
+
+  def run(trace: Trace[WriterS], x: Vector[String], y: Vector[String]): Vector[String] =
+    (for {
+      _ <- x.traverseU(trace(one, _))
+      _ <- y.traverseU(trace(two, _))
+    } yield ()).run._1
+
+  def capture[A](f: PrintStream => ResultTIO[A])(check: String => org.specs2.execute.Result) = {
+    val baos = new ByteArrayOutputStream
+    val out = new PrintStream(baos, true, "UTF-8")
+    (f(out) must beOk) and check(new String(baos.toString))
+  }
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -10,9 +10,9 @@ object build extends Build {
       id = "mundane"
     , base = file(".")
     , settings = standardSettings ++ promulgate.library("com.ambiata.mundane", "ambiata-oss")
-    , aggregate = Seq(cli, control, data, error, io, parse, reflect, testing, testingExtra, time)
+    , aggregate = Seq(cli, control, data, error, io, parse, reflect, testing, testingExtra, time, trace)
     )
-    .dependsOn(cli, control, data, error, io, parse, reflect, testing, time)
+    .dependsOn(cli, control, data, error, io, parse, reflect, testing, time, trace)
 
   lazy val standardSettings = Defaults.coreDefaultSettings ++
                               projectSettings              ++
@@ -94,6 +94,15 @@ object build extends Build {
     )
   )
 
+  lazy val store = Project(
+    id = "store"
+  , base = file("mundane-store")
+  , settings = standardSettings ++ lib("store") ++ Seq[Settings](
+      name := "mundane-store"
+    ) ++ Seq[Settings](libraryDependencies ++= depend.scalaz ++ depend.testing ++ depend.bits ++ depend.stream)
+  )
+  .dependsOn(control, data, io, testing % "test", io % "test->test")
+
   lazy val testing = Project(
     id = "testing"
   , base = file("mundane-testing")
@@ -118,6 +127,15 @@ object build extends Build {
       name := "mundane-time"
     ) ++ Seq[Settings](libraryDependencies ++= depend.scalaz ++ depend.joda ++ depend.testing)
   ).dependsOn(data)
+
+  lazy val trace = Project(
+    id = "trace"
+  , base = file("mundane-trace")
+  , settings = standardSettings ++ lib("trace") ++ Seq[Settings](
+      name := "mundane-trace"
+    ) ++ Seq[Settings](libraryDependencies ++= depend.scalaz ++ depend.testing)
+  )
+  .dependsOn(data, control, io, testing % "test")
 
   lazy val compilationSettings: Seq[Settings] = Seq(
     javacOptions ++= Seq("-Xmx3G", "-Xms512m", "-Xss4m"),


### PR DESCRIPTION
The general idea is that this can be used in Writer mode
for pure computations, and in IO mode for effectful
computations. Lifting between Writer and IO should
flush to disk.

This should replace bespoke cases of passing around logger
function, and the incorrect usage of Writer for debugging
messages.

/cc @etorreborre @charleso for review. This is roughly what I would like to replace most usages of Writer from  `Aws` with and also the IOAction log function. 
