### PR TITLE
Fix locations so that paths are proper paths

### DIFF
--- a/mundane-io/src/main/scala/com/ambiata/mundane/io/Location.scala
+++ b/mundane-io/src/main/scala/com/ambiata/mundane/io/Location.scala
@@ -1,37 +1,49 @@
 package com.ambiata.mundane.io
 
-import java.net.URI
-
 import scalaz._, Scalaz._
 
-sealed trait Location {
-  def path: DirPath
+sealed trait Location
+
+case class HdfsLocation(path: String) extends Location {
+  def dirPath  = DirPath.unsafe(path)
+  def filePath = FilePath.unsafe(path)
 }
 
-case class HdfsLocation(path: DirPath) extends Location
-
-case class S3Location(path: DirPath) extends Location {
-  def bucket: String = path.rootname.basename.name
-  def key: String = path.fromRoot.path
+object HdfsLocation {
+  def create(dir: DirPath): HdfsLocation =
+    HdfsLocation(dir.path)
 }
 
-case class LocalLocation(path: DirPath) extends Location
+case class S3Location(bucket: String, key: String) extends Location
+
+case class LocalLocation(path: String) extends Location {
+  def dirPath  = DirPath.unsafe(path)
+  def filePath = FilePath.unsafe(path)
+}
+
+object LocalLocation {
+  def create(dir: DirPath): LocalLocation =
+    LocalLocation(dir.path)
+}
 
 object Location {
   def fromUri(s: String): String \/ Location = try {
     val uri = new java.net.URI(s)
-    val dirPath = DirPath.unsafe(s)
-
     uri.getScheme match {
-      case "hdfs" => HdfsLocation (dirPath).right
-      case "s3"   => S3Location   (dirPath).right
-      case "file" => LocalLocation(dirPath).right
-      case null   => LocalLocation(dirPath).right
-      case _      => s"Unknown or invalid repository scheme [${uri.getScheme}]".left
+      case "hdfs" =>
+        HdfsLocation(uri.getPath).right
+      case "s3" =>
+        S3Location(uri.getHost, uri.getPath.drop(1)).right
+      case "file" =>
+        LocalLocation(uri.toURL.getFile).right
+      case null =>
+        LocalLocation(uri.getPath).right
+      case _ =>
+        s"Unknown or invalid repository scheme [${uri.getScheme}]".left
     }
   } catch {
-    case e: java.net.URISyntaxException => e.getMessage.left
+    case e: java.net.URISyntaxException =>
+      e.getMessage.left
   }
-
 }
 

--- a/mundane-io/src/test/scala/com/ambiata/mundane/io/FilePathSpec.scala
+++ b/mundane-io/src/test/scala/com/ambiata/mundane/io/FilePathSpec.scala
@@ -27,6 +27,10 @@ class FilePathSpec extends Specification { def is = s2"""
    ${ DirPath.unsafe(new File("/hello/world")).path === "/hello/world"  }
    a URI
    ${ DirPath.unsafe(new URI("hello/world")).path === "hello/world"  }
+   ${ DirPath.unsafe(new URI("hdfs://100.100.1:9000/hello/world")).path === "/hello/world"  }
+   ${ DirPath.unsafe(new URI("hdfs:/hello/world")).path === "/hello/world"  }
+   ${ DirPath.unsafe(new URI("file:/hello/world")).path === "/hello/world"  }
+   ${ DirPath.unsafe(new URI("s3://hello/world")).path === "/world"  }
 
  An absolute dir path can be built from
    a string starting with a /
@@ -45,9 +49,6 @@ class FilePathSpec extends Specification { def is = s2"""
    ${ (DirPath.Empty </> "world").isRelative }
    a literal string
    ${ ("hello" </> "world").isRelative }
-
- The DirPath loses its scheme if created from a string/file/uri
-   ${ DirPath.unsafe(new URI("s3://hello/world")).path === "/hello/world"  }
 
  Basic operations can be executed on a DirPath
    get the parent

--- a/mundane-io/src/test/scala/com/ambiata/mundane/io/LocationSpec.scala
+++ b/mundane-io/src/test/scala/com/ambiata/mundane/io/LocationSpec.scala
@@ -1,0 +1,17 @@
+package com.ambiata.mundane.io
+
+import Location._
+import org.specs2.Specification
+import scalaz._, Scalaz._
+
+class LocationSpec extends Specification { def is = s2"""
+
+ A Location can be created from a URI
+   ${ fromUri("hello/world") ==== LocalLocation("hello/world").right }
+   ${ fromUri("hdfs://100.100.1:9000/hello/world") ==== HdfsLocation("/hello/world").right }
+   ${ fromUri("hdfs:/hello/world") ==== HdfsLocation("/hello/world").right }
+   ${ fromUri("file:/hello/world") ==== LocalLocation("/hello/world").right }
+   ${ fromUri("s3://hello/world") ==== S3Location("hello", "world").right }
+
+"""
+}

--- a/mundane-store/src/test/scala/com/ambiata/mundane/store/PosixStoreSpec.scala
+++ b/mundane-store/src/test/scala/com/ambiata/mundane/store/PosixStoreSpec.scala
@@ -63,8 +63,12 @@ class PosixStoreSpec extends Specification with ScalaCheck { def is = isolated ^
       store.list(Key.Root / "sub") must beOkLike((_:List[Key]).toSet must_== keys.map(_.fromRoot).toSet) })
 
   def listFromPrefixEmpty =
-    prop((keys: Keys) =>
-      store.list(Key.Root / "sub") must beOkLike((_:List[Key]) must beEmpty))
+    prop { keys: Keys =>
+      val action =
+        Directories.mkdirs(store.root </> "sub") >>
+        store.list(Key.Root / "sub")
+      action must beOkLike((_:List[Key]) must beEmpty)
+    }
 
   def listHeadPrefixes =
     prop((keys: Keys) => clean(keys.map(_ prepend "sub")) { keys =>
@@ -99,7 +103,7 @@ class PosixStoreSpec extends Specification with ScalaCheck { def is = isolated ^
       keys.traverseU(store.existsPrefix) must beOkLike(_.forall(identity)) })
 
   def notExists =
-    prop((keys: Keys) => store.exists("root" / "i really don't exist") must beOkValue(false))
+    prop((keys: Keys) => store.exists("root" / "missing") must beOkValue(false))
 
   def delete =
     prop((keys: Keys) => clean(keys) { keys =>


### PR DESCRIPTION
Fix for `Location` so that:
- `Location` are properly created from `URI`s more or less using the `URI.getPath` method
- `S3Location` is back to containing a bucket/key distinction

This modification is made to fix Ivory where the `DirPath.relativeTo` method was not properly working on malformed HDFS locations (containing the host name when they shouldn't).
