### PR TITLE
Added some list parser combinators, for pairs and maps

### DIFF
--- a/mundane-parse/src/main/scala/com/ambiata/mundane/parse/ListParser.scala
+++ b/mundane-parse/src/main/scala/com/ambiata/mundane/parse/ListParser.scala
@@ -96,10 +96,10 @@ case class ListParser[A](parse: (Int, List[String]) => ParseResult[A]) {
       case xs => parse(position, xs).map(_.map(Option.apply[A]))
     })
 
-  def commaDelimited(delimiter: Char = ','): ListParser[Seq[A]] =
+  def commaDelimited: ListParser[List[A]] =
     delimited(',')
 
-  def delimited(delimiter: Char): ListParser[Seq[A]] =
+  def delimited(delimiter: Char): ListParser[List[A]] =
     ListParser.delimitedValues(this, delimiter)
 
   def bracketed(opening: Char, closing: Char): ListParser[A] =
@@ -271,7 +271,7 @@ object ListParser {
   /**
    * A parser for a list delimited values of the same type
    */
-  def delimitedValues[A](p: ListParser[A], delimiter: Char): ListParser[Seq[A]] =
+  def delimitedValues[A](p: ListParser[A], delimiter: Char): ListParser[List[A]] =
     ListParser((position, state) => state match {
       case h :: t =>
         val parsed = repeat(p).parse(Delimited.parseRow(h, delimiter).filter(_.nonEmpty))
@@ -283,8 +283,8 @@ object ListParser {
   /**
    * A parser that repeats the application of another parser until all the input is consumed
    */
-  def repeat[A](p: ListParser[A]): ListParser[Seq[A]] =
-    emptySeq ||| p.flatMap(a => repeat(p).map(seq => a +: seq))
+  def repeat[A](p: ListParser[A]): ListParser[List[A]] =
+    emptyList ||| p.flatMap(a => repeat(p).map(seq => a +: seq))
 
   /**
    * A parser for a value that is surrounded by 2 other characters
@@ -325,14 +325,14 @@ object ListParser {
   /**
    * A parser that succeeds on an empty list and returns an empty sequence
    */
-  def emptySeq[A]: ListParser[Seq[A]] =
+  def emptyList[A]: ListParser[List[A]] =
     empty(Nil)
 
   /**
    * A parser that returns 0.0 on an empty list or parses a Double
    */
   def doubleOrZero: ListParser[Double] =
-    empty(0.0) ||| double.named("double")
+    empty(0.0) ||| double
 
   /**
    * A parser that returns 0 on an empty list or parses an Int

--- a/mundane-parse/src/test/scala/com/ambiata/mundane/parse/ListParserSpec.scala
+++ b/mundane-parse/src/test/scala/com/ambiata/mundane/parse/ListParserSpec.scala
@@ -66,6 +66,30 @@ Properties
   fail always fails                               ${alwaysFails}
 
 
+Convenience methods
+===================
+
+  ${ emptyString.run(Nil) ==== ListParser.empty("").run(Nil) }
+  ${ emptyList.run(Nil)   ==== ListParser.empty(Nil).run(Nil) }
+
+  ${ prop((list: List[Double]) =>
+      doubleOrZero.run(list.map(_.toString)) ==== (ListParser.empty(0.0) ||| double).run(list.map(_.toString))) }
+
+  ${ prop((list: List[Int]) =>
+      intOrZero.run(list.map(_.toString)) ==== (ListParser.empty(0) ||| int).run(list.map(_.toString))) }
+
+  ${ prop((list: List[Int]) =>
+      int.commaDelimited.run(List(list.mkString(","))) ==== int.delimited(',').run(List(list.mkString(",")))) }
+
+  ${ prop((list: List[Int]) =>
+      int.delimited(',').run(List(list.mkString(","))) ==== ListParser.delimitedValues(int, ',').run(List(list.mkString(",")))) }
+
+  ${ prop((list: List[Int]) =>
+      int.bracketed('(', ')').run("("+:list.map(_.toString):+")") ==== ListParser.bracketed(int, '(', ')').run("("+:list.map(_.toString):+")")) }
+
+  ${ prop((list: List[String]) =>
+      string.whenEmpty("A").run(list) ==== (ListParser.empty("A") ||| string).run(list)) }
+
 """
 
   def position1 = {


### PR DESCRIPTION
I've added some list parsers:
- `pair[A, B](pa: ListParser[A], pb: ListParser[B], delimiter: Char = ','): ListParser[(A,B)]` to parse pairs
- `def delimitedValues[A](p: ListParser[A], delimiter: Char = ','): ListParser[Seq[A]]`

This ones generalises the `delimited` method on `ListParser[A]` to allow `A` to be something else than a `String`. This is a breaking change for clients using a different delimiter than the default one (people might have written `string.delimiter(implicitly[String =:= String], delimiter = ':'` which is not very pleasing anyway)
- finally `def keyValueMap[K, V](key: ListParser[K], value: ListParser[V], entriesDelimiter: Char = ',', keyValueDelimiter: Char = ':'): ListParser[Map[K, V]]` for a key value map. This uses the previous combinators.
