### PR TITLE
Upgraded disorder and fixed Buffer.wrapArray when the array is empty

### DIFF
--- a/mundane-bytes/src/main/scala/com/ambiata/mundane/bytes/Buffer.scala
+++ b/mundane-bytes/src/main/scala/com/ambiata/mundane/bytes/Buffer.scala
@@ -51,7 +51,7 @@ object Buffer {
     wrapArray(new Array[Byte](initialSize), 0, 0)
 
   def wrapArray(bytes: Array[Byte], offset: Int, length: Int): Buffer = {
-    if (offset < 0 || offset >= bytes.length)
+    if (offset < 0 || offset > bytes.length)
       sys.error(s"Invalid offset $offset for array of length ${bytes.length}")
     if (length < 0 || offset + length > bytes.length)
       sys.error(s"Invalid length $length with offset $offset and array of length ${bytes.length}")

--- a/mundane-bytes/src/test/scala/com/ambiata/mundane/bytes/BufferSpec.scala
+++ b/mundane-bytes/src/test/scala/com/ambiata/mundane/bytes/BufferSpec.scala
@@ -65,7 +65,7 @@ class BufferSpec extends Specification with ScalaCheck { def is = s2"""
     Buffer.shift(b, o).offset ==== (b.offset + o)
   })
 
-  def shiftFail = prop((b: Buffer, n: NaturalIntSmall) =>
+  def shiftFail = prop((b: Buffer, n: PositiveIntSmall) =>
     Buffer.shift(b, b.length + n.value) must throwA[RuntimeException]
   )
 
@@ -86,7 +86,7 @@ class BufferSpec extends Specification with ScalaCheck { def is = s2"""
   def growLength = prop((b1: Buffer, n: NaturalIntSmall) => {
     val oldLength = b1.length
     val b2 = Buffer.grow(b1, n.value)
-    b2.length must beGreaterThan(oldLength)
+    b2.length must beGreaterThanOrEqualTo(oldLength)
   })
 
   def growHasCapacity = prop((b1: Buffer, n: NaturalIntSmall) => {

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -24,7 +24,7 @@ object depend {
   val testing = specs2.map(_ % "test")
 
   val disorder =
-    Seq("com.ambiata" %% "disorder" % "0.0.1-20150219021345-bfcf0db" % "test")
+    Seq("com.ambiata" %% "disorder" % "0.0.1-20150317050225-9c1f81e" % "test")
 
   def reflect(version: String) =
     Seq("org.scala-lang" % "scala-compiler" % version, "org.scala-lang" % "scala-reflect" % version) ++


### PR DESCRIPTION
The issue with `wrapArray` wasn't seen before because `NaturalIntSmall` was excluding `0`.